### PR TITLE
refactor: remove confirmation dialog for file removal in FileDisplay …

### DIFF
--- a/frontend/src/lib/components/displays/FileDisplay.svelte
+++ b/frontend/src/lib/components/displays/FileDisplay.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { File as FileIcon } from 'lucide-svelte';
-	import ConfirmDialog from '$lib/components/dialogs/ConfirmDialog.svelte';
 	import { _ } from 'svelte-i18n';
 	import type { FileRes } from '$lib/schemas/response/FileRes';
 
@@ -10,12 +9,6 @@
 	}
 
 	const { File, onRemoveFile }: FileDisplayProps = $props();
-
-	let showDeleteDialog = $state(false);
-
-	function removeFile() {
-		showDeleteDialog = false;
-	}
 </script>
 
 <div
@@ -27,25 +20,10 @@
 		type="button"
 		onclick={(e) => {
 			e.preventDefault();
-			showDeleteDialog = true;
+			onRemoveFile();
 		}}
 		class="btn preset-filled-error-500 ml-auto rounded-full p-2"
 	>
 		{$_('button.remove')}
 	</button>
 </div>
-
-<ConfirmDialog
-	isOpen={showDeleteDialog}
-	title="Confirm Deletion"
-	message={`Are you sure you want to remove "${File?.name}"?`}
-	confirmText="Delete"
-	danger={true}
-	onConfirm={() => {
-		removeFile();
-		onRemoveFile();
-	}}
-	onCancel={() => {
-		showDeleteDialog = false;
-	}}
-/>


### PR DESCRIPTION
# ✨ Key Changes

refactor: remove confirmation dialog for file removal in FileDisplay

As it does NOT delete files a remove confirm is overkill in this case

## Notes

The same thought could be applied to trainees but that action seems more seveere, so I think its fine. But atm it is inconsistent there too because the multiselect is applied immediately too

## 🚨 Checklist

- [x] I have reviewed my own code changes.
- [x] The pull request is small and manageable for review.
