### PR TITLE
Refactor block creation DTOs and mappers to remove learningUnitId, up…

### DIFF
--- a/backend/src/main/java/ch/nova_omnia/lernello/api/block/AIBlockRestController.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/api/block/AIBlockRestController.java
@@ -1,6 +1,9 @@
 package ch.nova_omnia.lernello.api.block;
 
+import java.util.UUID;
+
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,9 +27,9 @@ public class AIBlockRestController {
 
     @PostMapping("/generate")
     @PreAuthorize("hasAuthority('SCOPE_blocks:write')")
-    public TheoryBlockResDTO generateBlock(@Valid @RequestBody AIGeneratedBlockRequest dto) {
+    public TheoryBlockResDTO generateBlock(@Valid @RequestBody AIGeneratedBlockRequest dto, @PathVariable UUID learningUnitId) {
         TheoryBlock block = aiBlockService.generateTheoryBlockFromAI(
-                dto.fileIds(), dto.topic(), dto.position(), dto.learningUnitId()
+                dto.fileIds(), dto.topic(), dto.position(), learningUnitId
         );
         return blockMapper.toTheoryBlockResDTO(block);
     }

--- a/backend/src/main/java/ch/nova_omnia/lernello/api/block/MultipleChoiceBlockRestController.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/api/block/MultipleChoiceBlockRestController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,8 +33,7 @@ public class MultipleChoiceBlockRestController {
 
     @PostMapping("/create")
     @PreAuthorize("hasAuthority('SCOPE_blocks:write')")
-    public @Valid MultipleChoiceBlockResDTO createMultipleChoiceBlock(@Valid @RequestBody CreateMultipleChoiceBlockDTO createMultipleChoiceBlockDTO) {
-        UUID learningUnitId = createMultipleChoiceBlockDTO.learningUnitId();
+    public @Valid MultipleChoiceBlockResDTO createMultipleChoiceBlock(@Valid @RequestBody CreateMultipleChoiceBlockDTO createMultipleChoiceBlockDTO, @PathVariable UUID learningUnitId) {
         MultipleChoiceBlock createdMultipleChoiceBlock = blockService.createBlock(multipleChoiceBlockMapper.toEntity(createMultipleChoiceBlockDTO), learningUnitId);
         return blockMapper.toMultipleChoiceBlockResDTO(createdMultipleChoiceBlock);
     }

--- a/backend/src/main/java/ch/nova_omnia/lernello/api/block/QuestionBlockRestController.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/api/block/QuestionBlockRestController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,8 +34,7 @@ public class QuestionBlockRestController {
 
     @PostMapping("/create")
     @PreAuthorize("hasAuthority('SCOPE_blocks:write')")
-    public @Valid QuestionBlockResDTO createQuestionBlock(@Valid @RequestBody CreateQuestionBlockDTO createQuestionBlockDTO) {
-        UUID learningUnitId = createQuestionBlockDTO.learningUnitId();
+    public @Valid QuestionBlockResDTO createQuestionBlock(@Valid @RequestBody CreateQuestionBlockDTO createQuestionBlockDTO, @PathVariable UUID learningUnitId) {
         QuestionBlock createdQuestionBlock = blockService.createBlock(questionBlockMapper.toEntity(createQuestionBlockDTO), learningUnitId);
         return blockMapper.toQuestionBlockResDTO(createdQuestionBlock);
     }

--- a/backend/src/main/java/ch/nova_omnia/lernello/api/block/TheoryBlockRestController.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/api/block/TheoryBlockRestController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -32,8 +33,7 @@ public class TheoryBlockRestController {
 
     @PostMapping("/create")
     @PreAuthorize("hasAuthority('SCOPE_blocks:write')")
-    public @Valid TheoryBlockResDTO createTheoryBlock(@Valid @RequestBody CreateTheoryBlockDTO createTheoryBlockDTO) {
-        UUID learningUnitId = createTheoryBlockDTO.learningUnitId();
+    public @Valid TheoryBlockResDTO createTheoryBlock(@Valid @RequestBody CreateTheoryBlockDTO createTheoryBlockDTO, @PathVariable UUID learningUnitId) {
         TheoryBlock createdTheoryBlock = blockService.createBlock(theoryBlockMapper.toEntity(createTheoryBlockDTO), learningUnitId);
         return blockMapper.toTheoryBlockResDTO(createdTheoryBlock);
     }

--- a/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/AIGeneratedBlockRequest.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/AIGeneratedBlockRequest.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.NotNull;
 public record AIGeneratedBlockRequest(
                                       @NotNull List<UUID> fileIds,
                                       @NotBlank String topic,
-                                      int position,
-                                      @NotNull UUID learningUnitId
+                                      int position
 ) {
 }

--- a/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/CreateMultipleChoiceBlockDTO.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/CreateMultipleChoiceBlockDTO.java
@@ -1,7 +1,8 @@
 package ch.nova_omnia.lernello.dto.request.block.create;
 
+import static ch.nova_omnia.lernello.model.data.block.BlockType.MULTIPLE_CHOICE;
+
 import java.util.List;
-import java.util.UUID;
 
 import ch.nova_omnia.lernello.model.data.block.BlockType;
 import jakarta.validation.constraints.Min;
@@ -9,15 +10,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static ch.nova_omnia.lernello.model.data.block.BlockType.MULTIPLE_CHOICE;
-
 
 public record CreateMultipleChoiceBlockDTO(
         @NotNull BlockType type,
         @Size(min = 3, max = 40)
         @NotBlank String name,
         @Min(0) int position,
-        @NotNull UUID learningUnitId,
         @NotBlank String question,
         @NotNull List<String> possibleAnswers,
         @NotNull List<String> correctAnswers

--- a/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/CreateQuestionBlockDTO.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/CreateQuestionBlockDTO.java
@@ -1,6 +1,6 @@
 package ch.nova_omnia.lernello.dto.request.block.create;
 
-import java.util.UUID;
+import static ch.nova_omnia.lernello.model.data.block.BlockType.QUESTION;
 
 import ch.nova_omnia.lernello.model.data.block.BlockType;
 import jakarta.validation.constraints.Min;
@@ -8,14 +8,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static ch.nova_omnia.lernello.model.data.block.BlockType.QUESTION;
-
 public record CreateQuestionBlockDTO(
         @NotNull BlockType type,
         @Size(min = 3, max = 40)
         @NotBlank String name,
         @Min(0) int position,
-        @NotNull UUID learningUnitId,
         @NotBlank String question,
         @NotBlank String expectedAnswer
 ) implements CreateBlockDTO {

--- a/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/CreateTheoryBlockDTO.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/dto/request/block/create/CreateTheoryBlockDTO.java
@@ -1,6 +1,6 @@
 package ch.nova_omnia.lernello.dto.request.block.create;
 
-import java.util.UUID;
+import static ch.nova_omnia.lernello.model.data.block.BlockType.THEORY;
 
 import ch.nova_omnia.lernello.model.data.block.BlockType;
 import jakarta.validation.constraints.Min;
@@ -8,14 +8,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-import static ch.nova_omnia.lernello.model.data.block.BlockType.THEORY;
-
 public record CreateTheoryBlockDTO(
         @NotNull BlockType type,
         @Size(min = 3, max = 40)
         @NotBlank String name,
         @Min(0) int position,
-        @NotNull UUID learningUnitId,
         @NotBlank String content
 ) implements CreateBlockDTO {
     public CreateTheoryBlockDTO {

--- a/backend/src/main/java/ch/nova_omnia/lernello/mapper/block/MultipleChoiceBlockMapper.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/mapper/block/MultipleChoiceBlockMapper.java
@@ -12,7 +12,7 @@ public interface MultipleChoiceBlockMapper {
 
     @Mapping(target = "type", constant = "MULTIPLE_CHOICE")
     @Mapping(target = "uuid", ignore = true)
-    @Mapping(target = "learningUnit.uuid", source = "learningUnitId")
+    @Mapping(target = "learningUnit", ignore = true)
     MultipleChoiceBlock toEntity(CreateMultipleChoiceBlockDTO createMultipleChoiceBlock);
 
     @Mapping(target = "type", constant = "MULTIPLE_CHOICE")

--- a/backend/src/main/java/ch/nova_omnia/lernello/mapper/block/QuestionBlockMapper.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/mapper/block/QuestionBlockMapper.java
@@ -12,7 +12,7 @@ public interface QuestionBlockMapper {
 
     @Mapping(target = "type", constant = "QUESTION")
     @Mapping(target = "uuid", ignore = true)
-    @Mapping(target = "learningUnit.uuid", source = "learningUnitId")
+    @Mapping(target = "learningUnit", ignore = true)
     QuestionBlock toEntity(CreateQuestionBlockDTO createQuestionBlockDTO);
 
     @Mapping(target = "type", constant = "QUESTION")

--- a/backend/src/main/java/ch/nova_omnia/lernello/mapper/block/TheoryBlockMapper.java
+++ b/backend/src/main/java/ch/nova_omnia/lernello/mapper/block/TheoryBlockMapper.java
@@ -12,7 +12,7 @@ public interface TheoryBlockMapper {
 
     @Mapping(target = "type", constant = "THEORY")
     @Mapping(target = "uuid", ignore = true)
-    @Mapping(target = "learningUnit.uuid", source = "learningUnitId")
+    @Mapping(target = "learningUnit", ignore = true)
     TheoryBlock toEntity(CreateTheoryBlockDTO createTheoryBlockDTO);
 
     @Mapping(target = "type", constant = "THEORY")

--- a/frontend/src/lib/schemas/request/CreateBlock.ts
+++ b/frontend/src/lib/schemas/request/CreateBlock.ts
@@ -6,7 +6,6 @@ export const CreateTheoryBlockSchema = z.object({
 	type: z.literal(BlockType.Enum.THEORY),
 	name: z.string().min(3).max(40),
 	position: z.number().min(0),
-	learningUnitId: z.string().uuid().nullable().optional(),
 	content: z.string().min(1).nullable().optional()
 });
 
@@ -14,7 +13,6 @@ export const CreateMultipleChoiceBlockSchema = z.object({
 	type: z.literal(BlockType.Enum.MULTIPLE_CHOICE),
 	name: z.string().min(3).max(40),
 	position: z.number().min(0),
-	learningUnitId: z.string().uuid().nullable().optional(),
 	question: z.string().min(1),
 	possibleAnswers: z.array(z.string().min(1)),
 	correctAnswers: z.array(z.string().min(1))

--- a/frontend/src/lib/states/blockActionState.svelte.ts
+++ b/frontend/src/lib/states/blockActionState.svelte.ts
@@ -117,7 +117,6 @@ export function queueBlockAction(action: BlockActionWithQuickAdd) {
 					type: action.data.type,
 					name: action.data.name,
 					position: action.data.position,
-					learningUnitId: action.data.learningUnitId || 'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF', // Placeholder id
 					content: action.data.content || 'placeholder'
 				}
 			};
@@ -130,7 +129,6 @@ export function queueBlockAction(action: BlockActionWithQuickAdd) {
 					type: action.data.type,
 					name: action.data.name,
 					position: action.data.position,
-					learningUnitId: action.data.learningUnitId || 'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF', // Placeholder id
 					question: action.data.question || 'placeholder question',
 					possibleAnswers: action.data.possibleAnswers || [],
 					correctAnswers: action.data.correctAnswers || []


### PR DESCRIPTION
…date controller methods to accept learningUnitId as a path variable

# ✨ Key Changes

DTOs now dont include the ID of their parents, since the ID is included in pathvariable
---

## 🚧 Incomplete Areas / Discussion Points

only did changes for blocks. the learningunit DTO (createLearningUnit) 

## 🚨 Checklist

- [x] I have reviewed my own code changes.
- [x] The pull request is small and manageable for review.
