### PR TITLE
feat: implement upload file for learning kits

### DIFF
--- a/frontend/src/lib/components/FileUpload.svelte
+++ b/frontend/src/lib/components/FileUpload.svelte
@@ -1,26 +1,126 @@
 <script lang="ts">
-	import { FileUpload } from '@skeletonlabs/skeleton-svelte';
-	import { Upload as IconUpload } from 'lucide-svelte';
+	import { api } from '$lib/api/apiClient';
+	import { uploadFile } from '$lib/api/collections/file';
+	import type { FileRes } from '$lib/schemas/response/FileRes';
+	import { toaster } from '$lib/states/toasterState.svelte';
+	import { FileUpload, type FileUploadApi } from '@skeletonlabs/skeleton-svelte';
+	import { createMutation } from '@tanstack/svelte-query';
+	import { UploadIcon } from 'lucide-svelte';
+	import { onMount } from 'svelte';
 	import { _ } from 'svelte-i18n';
 
-	// JOSI: TODO
-	// async function handleUploadFile() {
-	// 	const createdFile = { name };
-	// 	await api(fetch).req(uploadFile, createdFile).parse();
-	// }
+	interface FileUploadProps {
+		onFileUploaded: (uploadedFileInfo: FileRes) => void;
+	}
+
+	let { onFileUploaded }: FileUploadProps = $props();
+
+	const uploadFileMutation = createMutation({
+		mutationFn: (data: FormData) => api(fetch).req(uploadFile, data).parse(),
+		onMutate: () => {
+			toaster.create({
+				title: $_('files.upload.uploading'),
+				description: $_('files.upload.uploading.description'),
+				type: 'info'
+			});
+		},
+		onSuccess: (uploadedFileInfo) => {
+			onFileUploaded(uploadedFileInfo);
+		},
+		onError: (error) => {
+			console.error('Error uploading file:', error);
+			toaster.create({
+				title: $_('common.error.title'),
+				description: $_('error.description', { values: { status: 'unknown' } }),
+				type: 'error'
+			});
+		}
+	});
+	let fileApi: FileUploadApi | null = $state(null);
+	let isDraggingFile = $state(false);
+
+	onMount(() => {
+		let dragCounter = 0;
+		function onDragEnter(event: DragEvent) {
+			if (event.dataTransfer?.types?.includes('Files')) {
+				dragCounter++;
+				isDraggingFile = true;
+			}
+		}
+		function onDragOver(event: DragEvent) {
+			if (event.dataTransfer?.types?.includes('Files')) {
+				event.preventDefault();
+			}
+		}
+		function onDrop(event: DragEvent) {
+			dragCounter = 0;
+			isDraggingFile = false;
+			if (event.dataTransfer?.files) {
+				const files = Array.from(event.dataTransfer.files);
+				if (files.length > 0) {
+					fileApi?.setFiles(files);
+				}
+			}
+		}
+		function onDragLeave() {
+			dragCounter--;
+			if (dragCounter <= 0) {
+				isDraggingFile = false;
+			}
+		}
+		window.addEventListener('dragenter', onDragEnter);
+		window.addEventListener('dragover', onDragOver);
+		window.addEventListener('dragleave', onDragLeave);
+		window.addEventListener('drop', onDrop);
+		return () => {
+			window.removeEventListener('dragenter', onDragEnter);
+			window.removeEventListener('dragover', onDragOver);
+			window.removeEventListener('dragleave', onDragLeave);
+			window.removeEventListener('drop', onDrop);
+		};
+	});
 </script>
 
-<button type="button" class="btn preset-outlined-surface-500 h-fit">
+<div>
+	{#if $uploadFileMutation.isPending}
+		<div class="fixed inset-0 flex items-center justify-center backdrop-blur-3xl">
+			<h1 class="h1">UPLOADING...</h1>
+		</div>
+	{/if}
 	<FileUpload
-		classes="w-full"
 		accept=".pdf,.jpg,.jpeg,.png,.mp3,.mp4"
-		onFileChange={console.log}
-		onFileReject={console.error}
+		onFileReject={(details) => {
+			details.files.forEach((file) => {
+				file.errors.forEach((error) => {
+					toaster.create({
+						title: $_('files.upload.reject.title'),
+						description: $_('files.upload.reject.description', { values: { reason: error } }),
+						type: 'info'
+					});
+				});
+			});
+		}}
+		onFileAccept={(details) => {
+			if (!fileApi) throw new Error('FileUpload API not initialized');
+			details.files.forEach((file) => {
+				const formData = new FormData();
+				formData.append('file', file);
+				$uploadFileMutation.mutate(formData);
+			});
+			fileApi.clearFiles();
+		}}
+		onApiReady={(api) => {
+			fileApi = api;
+		}}
 		maxFiles={1024 * 1024 * 10}
 	>
-		<button class=" text-surface-900-100 font- m-auto flex justify-center gap-3">
-			<IconUpload size={24} />
+		<button class="btn preset-outlined-surface-500">
+			<UploadIcon size={24} />
 			{$_('addNewFile')}
 		</button>
 	</FileUpload>
-</button>
+</div>
+
+{#if isDraggingFile}
+	<div class="pointer-events-none fixed inset-0 border-4 border-dashed border-blue-500"></div>
+{/if}

--- a/frontend/src/lib/components/learningkit/tab/FilesTab.svelte
+++ b/frontend/src/lib/components/learningkit/tab/FilesTab.svelte
@@ -48,7 +48,16 @@
 			<h2 class="preset-typo-subtitle">{$_('common.files')}</h2>
 			<p>{$_('learningKit.context.description')}</p>
 		</div>
-		<FileUpload />
+		<FileUpload
+			onFileUploaded={(fileInfo) => {
+				$updateLearningKitMutation.mutate({
+					id: learningKitId,
+					data: {
+						files: [...files.map((file) => file.uuid), fileInfo.uuid]
+					}
+				});
+			}}
+		/>
 	</div>
 	<div class="flex flex-col gap-4">
 		<MultiSelect

--- a/frontend/src/lib/i18n/locales/de.json
+++ b/frontend/src/lib/i18n/locales/de.json
@@ -74,7 +74,7 @@
 	"learningKit.addFile": "Datei hinzufügen",
 	"learningKit.checkpoint": "Meilenstein",
 	"learningKit.checkpoint.description": "Teilnehmer müssen alle oben genannten Lerneinheiten abschließen, um Zugriff auf den Rest zu erhalten.",
-	"learningKit.context.description": "Der Kontext für die KI-Unterstützung",
+	"learningKit.context.description": "Der bereitgestellte Kontext für die KI-Unterstützungswerkzeuge. Dateien überall hinziehen, um sie hochzuladen.",
 	"learningKit.create": "Lernkit erstellen",
 	"learningKit.error.loadList": "Lernkits konnten nicht geladen werden",
 	"learningKit.error.loadSingle": "Lernkit konnte nicht geladen werden",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -74,7 +74,7 @@
 	"learningKit.addFile": "Add File",
 	"learningKit.checkpoint": "Checkpoint",
 	"learningKit.checkpoint.description": "Trainees must complete all the above Learning Units, before gaining access to the rest.",
-	"learningKit.context.description": "The context provided to the AI assisting tools",
+	"learningKit.context.description": "The context provided to the AI assisting tools. Drag files anywhere to upload.",
 	"learningKit.create": "Create Learning Kit",
 	"learningKit.update": "Update Learning Kit",
 	"learningKit.error.loadList": "Failed to load Learning Kits",

--- a/frontend/src/lib/i18n/locales/en.json
+++ b/frontend/src/lib/i18n/locales/en.json
@@ -116,5 +116,9 @@
 	"sidebar.toggleSidebar": "Toggle Sidebar",
 	"trainee.access": "These Trainees have access to the course",
 	"trainee.add": "Manage Trainees",
-	"trainee.form.title": "Create a new Trainee"
+	"trainee.form.title": "Create a new Trainee",
+	"files.upload.uploading": "Uploading...",
+	"files.upload.uploading.description": "File is being uploaded",
+	"files.upload.reject.title": "File rejected",
+	"files.upload.reject.description": "File rejected ({reason})"
 }

--- a/frontend/src/lib/i18n/locales/fr.json
+++ b/frontend/src/lib/i18n/locales/fr.json
@@ -74,7 +74,7 @@
 	"learningKit.addFile": "Ajouter un fichier",
 	"learningKit.checkpoint": "Point de contrôle",
 	"learningKit.checkpoint.description": "Les participants doivent terminer toutes les unités d'apprentissage ci-dessus pour accéder au reste.",
-	"learningKit.context.description": "Contexte fourni aux outils d'IA",
+	"learningKit.context.description": "Le contexte fourni aux outils d'IA. Faites glisser des fichiers n'importe où pour les télécharger.",
 	"learningKit.create": "Créer un kit d'apprentissage",
 	"learningKit.error.loadList": "Echec du chargement des kits d'apprentissage",
 	"learningKit.error.loadSingle": "Echec du chargement du kit d'apprentissage",

--- a/frontend/src/lib/i18n/locales/it.json
+++ b/frontend/src/lib/i18n/locales/it.json
@@ -74,7 +74,7 @@
 	"learningKit.addFile": "Aggiungi file",
 	"learningKit.checkpoint": "Punto di controllo",
 	"learningKit.checkpoint.description": "I partecipanti devono completare tutte le unita di apprendimento sopra per accedere al resto.",
-	"learningKit.context.description": "Contesto fornito agli strumenti IA",
+	"learningKit.context.description": "Il contesto fornito agli strumenti IA. Trascina i file ovunque per caricarli.",
 	"learningKit.create": "Crea kit di apprendimento",
 	"learningKit.error.loadList": "Impossibile caricare i kit di apprendimento",
 	"learningKit.error.loadSingle": "Impossibile caricare il kit di apprendimento",


### PR DESCRIPTION
# ✨ Key Changes

- Allows dragging files into screen to upload or alternatively use the upload button for learning kits

Notes: Uploading files with the same name is currently not possible because of how the BE is configured, this should be changed, files are identified by uuid, not name

## 🚨 Checklist

- [x] I have reviewed my own code changes.
- [x] The pull request is small and manageable for review.
