### PR TITLE
Add dividers to block selectpopover.svelte

### DIFF
--- a/frontend/src/lib/components/blocks/BlockSelectPopover.svelte
+++ b/frontend/src/lib/components/blocks/BlockSelectPopover.svelte
@@ -118,16 +118,19 @@
 	}
 </script>
 
-<div>
+<div class="flex items-center gap-2">
+	<hr class="hr border-dashed" />
 	<!-- Reference Element -->
 	<button
 		bind:this={floating.elements.reference}
 		{...interactions.getReferenceProps()}
-		class="btn w-full"
+		class="btn"
 	>
 		<PlusCircle class="h-4 w-4" />
 	</button>
 	<!-- Floating Element -->
+	<hr class="hr border-dashed" />
+
 	{#if open}
 		<div
 			bind:this={floating.elements.floating}

--- a/frontend/src/lib/components/blocks/BlockSelectPopover.svelte
+++ b/frontend/src/lib/components/blocks/BlockSelectPopover.svelte
@@ -118,19 +118,18 @@
 	}
 </script>
 
-<div class="flex items-center gap-2">
-	<hr class="hr border-dashed" />
+<div class="flex items-center gap-2 p-2">
 	<!-- Reference Element -->
+	<hr class="hr border-t-2 border-dashed border-gray-400" />
 	<button
 		bind:this={floating.elements.reference}
 		{...interactions.getReferenceProps()}
-		class="btn"
+		class="btn text-gray-400"
 	>
 		<PlusCircle class="h-4 w-4" />
 	</button>
+	<hr class="hr border-t-2 border-dashed border-gray-400" />
 	<!-- Floating Element -->
-	<hr class="hr border-dashed" />
-
 	{#if open}
 		<div
 			bind:this={floating.elements.floating}


### PR DESCRIPTION
# ✨ Key Changes

> it just adds a divier for the blockeditor

<img width="1079" alt="image" src="https://github.com/user-attachments/assets/d4ecbc0c-f60c-485a-abcc-5dfa46d0215e" />


---


## 🚨 Checklist

- [x] I have reviewed my own code changes.
- [x] The pull request is small and manageable for review.
