### PR TITLE
fix: update JWT expiration time to 7 days

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,7 +16,7 @@ spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=10MB
 
 jwt.secret=${JWT_SECRET:changemeeeeeeeeeeeeeeeeeeeeeeeee}
-jwt.expiration=${JWT_EXPIRATION:3600000}
+jwt.expiration=${JWT_EXPIRATION:604800000}
 
 spring.mail.host=mail.infomaniak.ch
 spring.mail.port=587


### PR DESCRIPTION
# ✨ Key Changes

While #383 is a proper refresh token, I think its too unstable and also over engineered for our prototype. We dont need to implement a full auth server, that would be replaced with an external auth service anyways for a production app. So now lets simply increase the access token expiry so you wont get logged out all the time

## 🚨 Checklist

- [x] I have reviewed my own code changes.
- [x] The pull request is small and manageable for review.
