### PR TITLE
fix: markdown editor accepts now one \n

### DIFF
--- a/frontend/src/lib/components/MarkdownEditor/TextEditor.svelte
+++ b/frontend/src/lib/components/MarkdownEditor/TextEditor.svelte
@@ -114,7 +114,7 @@
 	};
 
 	const previewContent = async (): Promise<string> => {
-		const parsed = await marked.parse(content);
+		const parsed = await marked.parse(content, { breaks: true });
 		return DOMPurify.sanitize(parsed);
 	};
 


### PR DESCRIPTION
# ✨ Key Changes

> markdown editor accepts now one \n instead of \n\n

---

## 🚧 Incomplete Areas / Discussion Points

> \-

## 🚨 Checklist

- [x] I have reviewed my own code changes.
- [x] The pull request is small and manageable for review.
